### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/emotion.client.ts
+++ b/src/runtime/emotion.client.ts
@@ -1,5 +1,5 @@
 import { hydrate } from '@emotion/css'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin((_) => {
   if (window.$emotionSSRIds) {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.